### PR TITLE
Fix for vulnerable dependency path

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "moment": "2.14.1",
     "morgan": "1.7.0",
     "pg": "6.0.1",
-    "request": "2.72.0",
+    "request": "2.74.0",
     "webpagetest": "0.3.4"
   }
 }


### PR DESCRIPTION
webpagetest-charts-api currently has a 3 vulnerable dependency paths, introducing 3 different types of known vulnerabilities.

This PR fixes  vulnerable dependency, [ReDOS vulnerability](https://snyk.io/vuln/npm:tough-cookie:20160722) in the `tough-cookie` dependency.
You can see [Snyk test report](https://snyk.io/test/github/trulia/webpagetest-charts-api) of this project for details. 

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, and will fix all the vulnerabilities listed above.

You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).

Note this PR fixes all the vulnerabilities introduced trough `request` dependency, in order to be vulnerability free you will need to upgrade others dependencies as well.

Full disclosure: I'm a part of the Snyk team, just looking to spread some security goodness and awareness ;)